### PR TITLE
Update License.txt

### DIFF
--- a/src/License.txt
+++ b/src/License.txt
@@ -14,4 +14,4 @@ In no event shall the authors or copyright holders be liable for any claim, dama
 whether in an action of contract, tort or otherwise, arising from, out of or in connection with the software
 or the use or other dealings in the software.
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the software.


### PR DESCRIPTION
There is a minor typo in the license text.
Nowhere else in the text is "the software" capitalised, so it shouldn't be here either.

I'm just being nitpicky.